### PR TITLE
Fix: Translate German entry to Spanish in es.json

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -12,7 +12,7 @@
   },
   "about": {
     "title": "My Story",
-    "story": "I’m a web developer from the Netherlands with {{years}} years of experience, starting with MS\u00A0Frontpage back in the day and continually advancing since then.",
+    "story": "I’m a web developer from the Netherlands with 15+ years of experience, starting with MS\u00A0Frontpage back in the day and continually advancing since then.",
     "skills": "I’m now working with React and Django to create dynamic web solutions. I’m also always exploring new tools to deliver exceptional results.",
     "hobbies": "Outside of work, I enjoy strolling in <0>Efteling</0>, a Dutch park with a unique enchanting charm. I also like to learn (human) languages."
   },

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -14,7 +14,7 @@
     "title": "Mi historia",
     "story": "Soy un desarrollador web de los Países Bajos con más de {{years}} años de experiencia, comenzando con MS Frontpage y mejorando continuamente desde entonces.",
     "skills": "Ahora trabajo con React y Django para crear soluciones web dinámicas. Siempre estoy explorando nuevas herramientas para ofrecer resultados sobresalientes.",
-    "hobbies": "Außerhalb der Arbeit genieße ich Spaziergänge im <0>Efteling</0>, einem niederländischen Park mit einem einzigartigen, bezaubernden Charme. Außerdem lerne ich gerne neue Sprachen."
+    "hobbies": "Fuera del trabajo, disfruto de paseos por el <0>Efteling</0>, un parque holandés con un encanto único y mágico. También me gusta aprender nuevos idiomas."
   },
   "work": {
     "title": "Proyectos en los que he trabajado",

--- a/src/pages/Home/About/index.jsx
+++ b/src/pages/Home/About/index.jsx
@@ -36,11 +36,10 @@ const About = () => {
           <SectionText>
             <Trans
               i18nKey="about.story"
-              values={{ years: 18 }} // Pass the dynamic number of years
-              components={{ sup: <PlusSup /> }}
-            >
-              I’m a web developer from the Netherlands with 18<sup>+</sup> years of experience.
-            </Trans>
+              components={{
+                0: <em />
+              }}
+            />
           </SectionText>
           <SectionText>
             {t('about.skills')}


### PR DESCRIPTION
- Corrected 'hobbies' entry in about section
- Ensures consistency in Spanish translations